### PR TITLE
Cleans up test files, alters trails schema, adds to getAllTrails tests

### DIFF
--- a/src/server/database/schema.sql
+++ b/src/server/database/schema.sql
@@ -15,8 +15,8 @@ CREATE TABLE trails (
 	latitude FLOAT8 DEFAULT 0,
 	longitude FLOAT8 DEFAULT 0,
 	distance FLOAT8 DEFAULT 0,
-	duration SMALLINT DEFAULT 0,
-	elevation SMALLINT DEFAULT 0,
+	duration FLOAT8 DEFAULT 0,
+	elevation FLOAT8 DEFAULT 0,
 	trail_image VARCHAR(128) DEFAULT '/trail_pictures/default-trail.png'
 );
 

--- a/src/test/model/database.test.js
+++ b/src/test/model/database.test.js
@@ -1,0 +1,7 @@
+/* eslint space-before-function-paren: ["error", "never"] */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint func-names: ["error", "never"] */
+/* eslint no-undef: 0 */
+
+import { expect } from 'chai';
+import { truncateDatabase } from '../utilities/database.utilities';

--- a/src/test/model/journals.test.js
+++ b/src/test/model/journals.test.js
@@ -1,0 +1,7 @@
+/* eslint space-before-function-paren: ["error", "never"] */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint func-names: ["error", "never"] */
+/* eslint no-undef: 0 */
+
+import { expect } from 'chai';
+import { truncateDatabase } from '../utilities/database.utilities';

--- a/src/test/model/pins.test.js
+++ b/src/test/model/pins.test.js
@@ -1,0 +1,7 @@
+/* eslint space-before-function-paren: ["error", "never"] */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint func-names: ["error", "never"] */
+/* eslint no-undef: 0 */
+
+import { expect } from 'chai';
+import { truncateDatabase } from '../utilities/database.utilities';

--- a/src/test/model/reviews.test.js
+++ b/src/test/model/reviews.test.js
@@ -1,0 +1,7 @@
+/* eslint space-before-function-paren: ["error", "never"] */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint func-names: ["error", "never"] */
+/* eslint no-undef: 0 */
+
+import { expect } from 'chai';
+import { truncateDatabase } from '../utilities/database.utilities';

--- a/src/test/model/trails.test.js
+++ b/src/test/model/trails.test.js
@@ -16,8 +16,8 @@ import {
 
 describe('trails database model', function() {
 	const name = 'Tuxachanie Trail';
-	const latitude = '30.666780';
-	const longitude = '-89.133125';
+	const latitude = 30.666780;
+	const longitude = -89.133125;
 	const distance = 12.1;
 	const duration = 4.03;
 	const elevation = 179.1;
@@ -51,7 +51,31 @@ describe('trails database model', function() {
 
 			it('should return a trail with a name', function() {
 				expect(testTrail.name).to.equal(name);
-			})
+			});
+
+			it('should return a trail with a latitude', function() {
+				expect(testTrail.latitude).to.equal(latitude);
+			});
+
+			it('should return a trail with a longitude', function() {
+				expect(testTrail.longitude).to.equal(longitude);
+			});
+
+			it('should return a trail with a distance', function() {
+				expect(testTrail.distance).to.equal(distance);
+			});
+
+			it('should return a trail with a duration', function() {
+				expect(testTrail.duration).to.equal(duration);
+			});
+
+			it('should return a trail with an elevation', function() {
+				expect(testTrail.elevation).to.equal(elevation);
+			});
+
+			it('should return a trail with a trail image', function() {
+				expect(testTrail.trail_image).to.equal(trailImage);
+			});
 		});
 	});
 

--- a/src/test/model/users.test.js
+++ b/src/test/model/users.test.js
@@ -1,4 +1,11 @@
+/* eslint space-before-function-paren: ["error", "never"] */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint func-names: ["error", "never"] */
+/* eslint no-undef: 0 */
+
 import { expect } from 'chai';
+import { truncateDatabase } from '../utilities/database.utilities';
+
 import {
 	getUserByEmail,
 	getUserById,

--- a/src/test/routes/auth.test.js
+++ b/src/test/routes/auth.test.js
@@ -1,0 +1,6 @@
+/* eslint space-before-function-paren: ["error", "never"] */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint func-names: ["error", "never"] */
+/* eslint no-undef: 0 */
+
+import { expect } from 'chai';

--- a/src/test/routes/trails.test.js
+++ b/src/test/routes/trails.test.js
@@ -1,0 +1,6 @@
+/* eslint space-before-function-paren: ["error", "never"] */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint func-names: ["error", "never"] */
+/* eslint no-undef: 0 */
+
+import { expect } from 'chai';

--- a/src/test/routes/users.test.js
+++ b/src/test/routes/users.test.js
@@ -1,0 +1,6 @@
+/* eslint space-before-function-paren: ["error", "never"] */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint func-names: ["error", "never"] */
+/* eslint no-undef: 0 */
+
+import { expect } from 'chai';


### PR DESCRIPTION
- Each test file now has blocking for unwanted eslint rules.
- Schema has been updated to change duration and distance in the trails table to be float8 instead of smallint. Smallint was causing a loss of data.
- getAllTrails now tests for each data point received from the database query which uncovered the unwanted loss of data due to smallint values.